### PR TITLE
Custom config rule to check that AMI target EBS encrypted

### DIFF
--- a/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED.py
+++ b/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED.py
@@ -1,0 +1,84 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+'''
+#####################################
+##           Gherkin               ##
+#####################################
+Rule Name:
+  AMI_EBS_ENCRYPTED
+
+Description:
+  Check EBS backed AMI are encrypted.
+
+Rationale:
+  Encrypting on EBS ensure that no data is written on disk in clear text.
+
+Indicative Severity:
+  Medium
+
+Trigger:
+  Configuration Change on AWS::EC2::Instance
+
+Reports on:
+  AWS::EC2::Instance
+
+Scenarios:
+  Scenario: 1
+    Given: Verify the AMI target EBS is Encrypted
+      And: AMI target EBS is encrypted
+     Then: Return COMPLIANT
+  Scenario: 2
+    Given: Verify the AMI target EBS is not Encrypted
+      And: AMI target EBS is not encrypted
+     Then: Return NON_COMPLIANT
+'''
+
+
+from rdklib import Evaluator, Evaluation, ConfigRule, ComplianceType
+DEFAULT_RESOURCE_TYPE = 'AWS::EC2::Volume'
+
+class AMI_EBS_ENCRYPTED(ConfigRule):
+
+    def evaluate_periodic(self, event, client_factory, valid_rule_parameters):
+        ec2_client = client_factory.build_client('ec2')
+        evaluations = []
+        amis = ec2_client.describe_images(Owners=["self"])
+
+        for ami in amis['Images']:
+            block_devices = ami['BlockDeviceMappings']
+            for block_device in block_devices:
+                if block_device['Ebs']['Encrypted']:
+                    evaluations.append(
+                        Evaluation(
+                            ComplianceType.COMPLIANT,
+                            ami['ImageId'],
+                            DEFAULT_RESOURCE_TYPE
+                        )
+                    )
+                else:
+                    evaluations.append(
+                        Evaluation(
+                            ComplianceType.NON_COMPLIANT,
+                            ami['ImageId'],
+                            DEFAULT_RESOURCE_TYPE
+                        )
+                    )
+        return evaluations
+
+
+################################
+# DO NOT MODIFY ANYTHING BELOW #
+################################
+def lambda_handler(event, context):
+    my_rule = AMI_EBS_ENCRYPTED()
+    evaluator = Evaluator(my_rule)
+    return evaluator.handle(event, context)

--- a/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED.py
+++ b/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED.py
@@ -17,7 +17,7 @@ Rule Name:
   AMI_EBS_ENCRYPTED
 
 Description:
-  Check EBS backed AMI are encrypted.
+  Check EBS-backed AMI are encrypted.
 
 Rationale:
   Encrypting on EBS ensure that no data is written on disk in clear text.
@@ -26,10 +26,10 @@ Indicative Severity:
   Medium
 
 Trigger:
-  Configuration Change on AWS::EC2::Instance
+  Periodic
 
 Reports on:
-  AWS::EC2::Instance
+  AWS::::Account
 
 Scenarios:
   Scenario: 1
@@ -44,7 +44,7 @@ Scenarios:
 
 
 from rdklib import Evaluator, Evaluation, ConfigRule, ComplianceType
-DEFAULT_RESOURCE_TYPE = 'AWS::EC2::Volume'
+DEFAULT_RESOURCE_TYPE = 'AWS::::Account'
 
 class AMI_EBS_ENCRYPTED(ConfigRule):
 
@@ -53,14 +53,15 @@ class AMI_EBS_ENCRYPTED(ConfigRule):
         evaluations = []
         amis = ec2_client.describe_images(Owners=["self"])
 
-        for ami in amis['Images']:
-            block_devices = ami['BlockDeviceMappings']
+        for ami in amis.get('Images'):
+            block_devices = ami.get('BlockDeviceMappings')
             for block_device in block_devices:
-                if block_device['Ebs']['Encrypted']:
+                ebs = block_device.get('Ebs')
+                if ebs and ebs['Encrypted']:
                     evaluations.append(
                         Evaluation(
                             ComplianceType.COMPLIANT,
-                            ami['ImageId'],
+                            ami.get('ImageId'),
                             DEFAULT_RESOURCE_TYPE
                         )
                     )
@@ -68,7 +69,7 @@ class AMI_EBS_ENCRYPTED(ConfigRule):
                     evaluations.append(
                         Evaluation(
                             ComplianceType.NON_COMPLIANT,
-                            ami['ImageId'],
+                            ami.get('ImageId'),
                             DEFAULT_RESOURCE_TYPE
                         )
                     )

--- a/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED.py
+++ b/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED.py
@@ -8,7 +8,6 @@
 # or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-
 '''
 #####################################
 ##           Gherkin               ##
@@ -17,7 +16,7 @@ Rule Name:
   AMI_EBS_ENCRYPTED
 
 Description:
-  Check EBS-backed AMI are encrypted.
+  Check EBS-backed AMI is encrypted.
 
 Rationale:
   Encrypting on EBS ensure that no data is written on disk in clear text.
@@ -33,17 +32,15 @@ Reports on:
 
 Scenarios:
   Scenario: 1
-    Given: Verify the AMI target EBS is Encrypted
-      And: AMI target EBS is encrypted
+    Given: AMI target EBS is encrypted
      Then: Return COMPLIANT
   Scenario: 2
-    Given: Verify the AMI target EBS is not Encrypted
-      And: AMI target EBS is not encrypted
+    Given: AMI target EBS is not encrypted
      Then: Return NON_COMPLIANT
 '''
 
-
 from rdklib import Evaluator, Evaluation, ConfigRule, ComplianceType
+
 DEFAULT_RESOURCE_TYPE = 'AWS::::Account'
 
 class AMI_EBS_ENCRYPTED(ConfigRule):
@@ -52,33 +49,17 @@ class AMI_EBS_ENCRYPTED(ConfigRule):
         ec2_client = client_factory.build_client('ec2')
         evaluations = []
         amis = ec2_client.describe_images(Owners=["self"])
-
         for ami in amis.get('Images'):
             block_devices = ami.get('BlockDeviceMappings')
             for block_device in block_devices:
                 ebs = block_device.get('Ebs')
                 if ebs and ebs['Encrypted']:
-                    evaluations.append(
-                        Evaluation(
-                            ComplianceType.COMPLIANT,
-                            ami.get('ImageId'),
-                            DEFAULT_RESOURCE_TYPE
-                        )
-                    )
+                    evaluations.append(Evaluation(ComplianceType.COMPLIANT, ami.get('ImageId'), DEFAULT_RESOURCE_TYPE))
                 else:
-                    evaluations.append(
-                        Evaluation(
-                            ComplianceType.NON_COMPLIANT,
-                            ami.get('ImageId'),
-                            DEFAULT_RESOURCE_TYPE
-                        )
-                    )
+                    evaluations.append(Evaluation(ComplianceType.NON_COMPLIANT, ami.get('ImageId'), DEFAULT_RESOURCE_TYPE,
+                                                  annotation="AMI target EBS is not encrypted"))
         return evaluations
 
-
-################################
-# DO NOT MODIFY ANYTHING BELOW #
-################################
 def lambda_handler(event, context):
     my_rule = AMI_EBS_ENCRYPTED()
     evaluator = Evaluator(my_rule)

--- a/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED_test.py
+++ b/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED_test.py
@@ -21,7 +21,7 @@ import rdklibtest
 ##############
 
 # Define the default resource to report to Config Rules
-RESOURCE_TYPE = 'AWS::EC2::Volume'
+RESOURCE_TYPE = 'AWS::::Account'
 
 #############
 # Main Code #
@@ -47,15 +47,9 @@ class ComplianceTest(unittest.TestCase):
         "Images": [
             {
                 "ImageId": "ami-0112c52e7ca89ee2e",
-                "State": "available",
                 "BlockDeviceMappings": [
                     {
-                        "DeviceName": "/dev/xvda",
                         "Ebs": {
-                            "SnapshotId": "snap-0d78c2a6eb35811af",
-                            "DeleteOnTermination": "True",
-                            "VolumeType": "gp2",
-                            "VolumeSize": 8,
                             "Encrypted": False
                         }
                     }
@@ -68,15 +62,10 @@ class ComplianceTest(unittest.TestCase):
         "Images": [
             {
                 "ImageId": "ami-08d7261cad6c06507",
-                "State": "available",
                 "BlockDeviceMappings": [
                     {
-                        "DeviceName": "/dev/sdb",
                         "Ebs": {
-                            "Encrypted": True,
-                            "DeleteOnTermination": "False",
-                            "VolumeType": "gp2",
-                            "VolumeSize": 8
+                            "Encrypted": True
                         }
                     }
                 ]
@@ -91,7 +80,6 @@ class ComplianceTest(unittest.TestCase):
         resp_expected = [
             Evaluation(ComplianceType.COMPLIANT, "ami-08d7261cad6c06507", RESOURCE_TYPE)
         ]
-
         rdklibtest.assert_successful_evaluation(self, response, resp_expected, 1)
 
     def test_non_compliant_ami(self):
@@ -100,5 +88,4 @@ class ComplianceTest(unittest.TestCase):
         resp_expected = [
             Evaluation(ComplianceType.NON_COMPLIANT, "ami-0112c52e7ca89ee2e", RESOURCE_TYPE)
         ]
-
         rdklibtest.assert_successful_evaluation(self, response, resp_expected, 1)

--- a/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED_test.py
+++ b/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED_test.py
@@ -1,0 +1,104 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import unittest
+from mock import patch, MagicMock
+from rdklib import Evaluation, ComplianceType
+import rdklibtest
+
+#############
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+RESOURCE_TYPE = 'AWS::EC2::Volume'
+
+#############
+# Main Code #
+#############
+
+MODULE = __import__('AMI_EBS_ENCRYPTED')
+RULE = MODULE.AMI_EBS_ENCRYPTED()
+
+CLIENT_FACTORY = MagicMock()
+
+#example for mocking S3 API calls
+EC2_CLIENT_MOCK = MagicMock()
+
+def mock_get_client(client_name, *args, **kwargs):
+    if client_name == 'ec2':
+        return EC2_CLIENT_MOCK
+    raise Exception("Attempting to create an unknown client")
+
+@patch.object(CLIENT_FACTORY, 'build_client', MagicMock(side_effect=mock_get_client))
+class ComplianceTest(unittest.TestCase):
+
+    non_encrypted_ami_ebs = {
+        "Images": [
+            {
+                "ImageId": "ami-0112c52e7ca89ee2e",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "SnapshotId": "snap-0d78c2a6eb35811af",
+                            "DeleteOnTermination": "True",
+                            "VolumeType": "gp2",
+                            "VolumeSize": 8,
+                            "Encrypted": False
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    encrypted_ami_ebs = {
+        "Images": [
+            {
+                "ImageId": "ami-08d7261cad6c06507",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sdb",
+                        "Ebs": {
+                            "Encrypted": True,
+                            "DeleteOnTermination": "False",
+                            "VolumeType": "gp2",
+                            "VolumeSize": 8
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+
+    def test_compliant_ami(self):
+        EC2_CLIENT_MOCK.describe_images.return_value = self.encrypted_ami_ebs
+        response = RULE.evaluate_periodic("", CLIENT_FACTORY, "")
+        resp_expected = [
+            Evaluation(ComplianceType.COMPLIANT, "ami-08d7261cad6c06507", RESOURCE_TYPE)
+        ]
+
+        rdklibtest.assert_successful_evaluation(self, response, resp_expected, 1)
+
+    def test_non_compliant_ami(self):
+        EC2_CLIENT_MOCK.describe_images.return_value = self.non_encrypted_ami_ebs
+        response = RULE.evaluate_periodic("", CLIENT_FACTORY, "")
+        resp_expected = [
+            Evaluation(ComplianceType.NON_COMPLIANT, "ami-0112c52e7ca89ee2e", RESOURCE_TYPE)
+        ]
+
+        rdklibtest.assert_successful_evaluation(self, response, resp_expected, 1)

--- a/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED_test.py
+++ b/python/AMI_EBS_ENCRYPTED/AMI_EBS_ENCRYPTED_test.py
@@ -14,25 +14,12 @@ from mock import patch, MagicMock
 from rdklib import Evaluation, ComplianceType
 import rdklibtest
 
-#############
-
-##############
-# Parameters #
-##############
-
-# Define the default resource to report to Config Rules
 RESOURCE_TYPE = 'AWS::::Account'
-
-#############
-# Main Code #
-#############
 
 MODULE = __import__('AMI_EBS_ENCRYPTED')
 RULE = MODULE.AMI_EBS_ENCRYPTED()
 
 CLIENT_FACTORY = MagicMock()
-
-#example for mocking S3 API calls
 EC2_CLIENT_MOCK = MagicMock()
 
 def mock_get_client(client_name, *args, **kwargs):
@@ -44,48 +31,39 @@ def mock_get_client(client_name, *args, **kwargs):
 class ComplianceTest(unittest.TestCase):
 
     non_encrypted_ami_ebs = {
-        "Images": [
-            {
-                "ImageId": "ami-0112c52e7ca89ee2e",
-                "BlockDeviceMappings": [
-                    {
-                        "Ebs": {
-                            "Encrypted": False
-                        }
-                    }
-                ]
-            }
-        ]
+        "Images": [{
+            "ImageId": "ami-0112c52e7ca89ee2e",
+            "BlockDeviceMappings": [{
+                "Ebs": {
+                    "Encrypted": False
+                }
+            }]
+        }]
     }
-
     encrypted_ami_ebs = {
-        "Images": [
-            {
-                "ImageId": "ami-08d7261cad6c06507",
-                "BlockDeviceMappings": [
-                    {
-                        "Ebs": {
-                            "Encrypted": True
-                        }
-                    }
-                ]
-            }
-        ]
+        "Images": [{
+            "ImageId": "ami-08d7261cad6c06507",
+            "BlockDeviceMappings": [{
+                "Ebs": {
+                    "Encrypted": True
+                }
+            }]
+        }]
     }
 
-
-    def test_compliant_ami(self):
+    def test_scenario1_amitargetebsencrypted_returnscompliant(self):
         EC2_CLIENT_MOCK.describe_images.return_value = self.encrypted_ami_ebs
         response = RULE.evaluate_periodic("", CLIENT_FACTORY, "")
         resp_expected = [
             Evaluation(ComplianceType.COMPLIANT, "ami-08d7261cad6c06507", RESOURCE_TYPE)
         ]
-        rdklibtest.assert_successful_evaluation(self, response, resp_expected, 1)
+        rdklibtest.assert_successful_evaluation(self, response, resp_expected)
 
-    def test_non_compliant_ami(self):
+    def test_scenario2_amitargetebsnotencrypted_returnsnoncompliant(self):
         EC2_CLIENT_MOCK.describe_images.return_value = self.non_encrypted_ami_ebs
         response = RULE.evaluate_periodic("", CLIENT_FACTORY, "")
         resp_expected = [
-            Evaluation(ComplianceType.NON_COMPLIANT, "ami-0112c52e7ca89ee2e", RESOURCE_TYPE)
+            Evaluation(ComplianceType.NON_COMPLIANT, "ami-0112c52e7ca89ee2e", RESOURCE_TYPE,
+                       annotation="AMI target EBS is not encrypted")
         ]
         rdklibtest.assert_successful_evaluation(self, response, resp_expected, 1)

--- a/python/AMI_EBS_ENCRYPTED/parameters.json
+++ b/python/AMI_EBS_ENCRYPTED/parameters.json
@@ -1,0 +1,13 @@
+{
+  "Version": "1.0",
+  "Parameters": {
+    "RuleName": "AMI_EBS_ENCRYPTED",
+    "SourceRuntime": "python3.6-lib",
+    "SourcePeriodic": "One_Hour",
+    "CodeKey": "AMI_EBS_ENCRYPTED.zip",
+    "InputParameters": "{}",
+    "OptionalParameters": "{}",
+    "SourceEvents": "AWS::EC2::Volume"
+  },
+  "Tags": "[]"
+}


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
